### PR TITLE
Fix SW to cache /screen.css

### DIFF
--- a/src/assets/service-worker.js
+++ b/src/assets/service-worker.js
@@ -11,7 +11,7 @@ self.addEventListener('install', function(event) {
 			return cache.addAll([
 				OFFLINE_URL,
 
-				'/styles/screen.css',
+				'/screen.css',
 				'/fonts/permanent-marker.woff',
 				'/favicon.ico',
 				'/images/icon-228x228.png',


### PR DESCRIPTION
Currently it's trying to cache `/styles/screen.css` which doesn't exist so the `cache.addAll` is failing. Problem exists on the live site currently.